### PR TITLE
Fetch release time with `yarn info`

### DIFF
--- a/lib/calculator.js
+++ b/lib/calculator.js
@@ -25,7 +25,7 @@ function assertPackagesAreInstalled(packages) {
   });
 }
 
-// - outdated - JSON string, the stdout from npm outdated.
+// - outdated - JSON string, the stdout from yarn outdated.
 // - releaseTime - function(packageName, version) returns a `moment`.
 //   Dependency injected to aid testing.
 // - stdout - Something we can write output to. Dependency injected to aid
@@ -54,10 +54,9 @@ function calculator(outdated, releaseTime, stdout) {
       throw({ message: msg, status: 2 });
     }
 
-    // Known issue: Each call to `releaseTime` runs `npm view`, which means two
-    // network requests that could be combined into one.
-    const currentMoment = releaseTime(key, currentVersion);
-    const latestMoment = releaseTime(key, latestVersion);
+    const releaseTimeMap = releaseTime(key);
+    const currentMoment = moment(releaseTimeMap[currentVersion]);
+    const latestMoment = moment(releaseTimeMap[latestVersion]);
 
     const yrs = years(currentMoment, latestMoment);
     sum += yrs;

--- a/lib/outdated.js
+++ b/lib/outdated.js
@@ -2,12 +2,12 @@
 
 var execSync = require('child_process').execSync;
 
-// Runs `npm outdated` and either returns a JSON string or exits the process.
+// Runs `yarn outdated` and either returns a JSON string or exits the process.
 function outdated() {
   const cmd = 'yarn outdated --json';
   let stdout;
   try {
-    stdout = execSync(cmd, { timeout: 30000 });
+    stdout = execSync(cmd, { timeout: 30000, encoding: 'utf8' });
   } catch(e) {
     // When yarn exits with status code 1, it is normal and indicates that some
     // packages are out of date.

--- a/lib/release-time.js
+++ b/lib/release-time.js
@@ -1,11 +1,9 @@
 'use strict';
 
-var _ = require('lodash');
 var execSync = require('child_process').execSync;
-var moment = require('moment');
 
-function releaseTime(packageName, version) {
-  var cmd = 'npm view --json ' + packageName;
+function releaseTime(packageName) {
+  var cmd = 'yarn info ' + packageName + ' time --json';
   var stdout = null;
   try {
     stdout = execSync(cmd);
@@ -15,11 +13,11 @@ function releaseTime(packageName, version) {
     process.exit(1);
   }
   if (stdout === '') {
-    process.stderr.write('npm view produced no output, no idea why');
+    process.stderr.write('yarn info produced no output, no idea why');
     process.exit(1);
   }
   var parsed = JSON.parse(stdout);
-  return moment(_.get(parsed, ['time', version]));
+  return parsed.data;
 }
 
 module.exports = releaseTime;

--- a/package.json
+++ b/package.json
@@ -3,15 +3,15 @@
   "version": "0.1.9",
   "description": "A simple measure of dependency freshness",
   "dependencies": {
-    "lodash": "^4.17.4",
-    "moment": "^2.17.1",
-    "sprintf-js": "^1.0.3"
+    "lodash": "^4.17.15",
+    "moment": "^2.24.0",
+    "sprintf-js": "^1.1.2"
   },
   "bin": {
     "libyear-yarn": "./bin/libyear-yarn"
   },
   "scripts": {
-    "test": "node_modules/.bin/jasmine"
+    "test": "jasmine"
   },
   "author": "Jared Beck and Leon Miller-Out",
   "license": "LGPL-3.0",
@@ -20,6 +20,6 @@
     "url": "https://github.com/sbleon/libyear-yarn"
   },
   "devDependencies": {
-    "jasmine": "^2.6.0"
+    "jasmine": "^3.5.0"
   }
 }

--- a/spec/calculator-spec.js
+++ b/spec/calculator-spec.js
@@ -1,6 +1,5 @@
 describe("calculator", function() {
   const calculator = require('../lib/calculator.js');
-  const moment = require('moment');
 
   it("is a function", () => {
     expect(typeof(calculator)).toEqual("function");
@@ -32,12 +31,12 @@ describe("calculator", function() {
           }
         }
       );
-      const releaseTime = (packageName, version) => {
+      const releaseTime = (packageName) => {
         return {
-          "1.0.0": moment("2016-02-28"),
-          "1.0.1": moment("2016-02-29"),
-          "2.0.0": moment("2017-02-28")
-        }[version];
+          "1.0.0": "2016-02-28",
+          "1.0.1": "2016-02-29",
+          "2.0.0": "2017-02-28"
+        };
       };
       const stdout = { write: () => {} };
       spyOn(stdout, 'write');


### PR DESCRIPTION
- use `yarn info` instead of `npm view`
- avoid redundant network request
- update dependencies