### PR TITLE
Small bugfix - libyear-yarn falls over when using direct git dependencies

### DIFF
--- a/lib/calculator.js
+++ b/lib/calculator.js
@@ -54,6 +54,10 @@ function calculator(outdated, releaseTime, stdout) {
       throw({ message: msg, status: 2 });
     }
 
+    if(latestVersion === 'exotic') {
+        return;
+    }
+
     const releaseTimeMap = releaseTime(key);
     const currentMoment = moment(releaseTimeMap[currentVersion]);
     const latestMoment = moment(releaseTimeMap[latestVersion]);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "libyear-yarn",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "description": "A simple measure of dependency freshness",
   "dependencies": {
     "lodash": "^4.17.15",

--- a/spec/calculator-spec.js
+++ b/spec/calculator-spec.js
@@ -48,4 +48,26 @@ describe("calculator", function() {
       expect(stdout.write).toHaveBeenCalledWith('System is 1.0 libyears behind\n');
     });
   });
+
+  describe("a package references a git endpoint", () => {
+    it("doesn't process 'exotic' versions", () => {
+      const outdated = JSON.stringify(
+        {
+          "type": "table",
+          "data": {
+            "head": [ "Package", "Current", "Wanted", "Latest", "Package Type", "URL" ],
+            "body": [
+              [ "banana", "1.5.1", "exotic", "exotic", "dependencies", "https://github.com/banana/banana.git#1.5.1"]
+            ]
+          }
+        }
+      );
+      const releaseTime = jasmine.createSpy();
+
+      const stdout = { write: () => {} };
+
+      calculator(outdated, releaseTime, stdout);
+      expect(releaseTime).not.toHaveBeenCalled();
+    });
+  });
 });


### PR DESCRIPTION
Thanks for the awesome package, I've had an issue where when `yarn outdated` returns a private github dependency, rather than a known NPM repo, it exits with an error that looks like:

```{"type":"error","data":"Received invalid response from npm."}
Unexpected end of JSON input
SyntaxError: Unexpected end of JSON input
    at JSON.parse (<anonymous>)
    at releaseTime (/Users/scarfs03/.config/yarn/global/node_modules/libyear-yarn/lib/release-time.js:19:21)
    at /Users/scarfs03/.config/yarn/global/node_modules/libyear-yarn/lib/calculator.js:57:28
    at /Users/scarfs03/.config/yarn/global/node_modules/lodash/lodash.js:4905:15
    at baseForOwn (/Users/scarfs03/.config/yarn/global/node_modules/lodash/lodash.js:2990:24)
    at /Users/scarfs03/.config/yarn/global/node_modules/lodash/lodash.js:4874:18
    at Function.forEach (/Users/scarfs03/.config/yarn/global/node_modules/lodash/lodash.js:9342:14)
    at calculator (/Users/scarfs03/.config/yarn/global/node_modules/libyear-yarn/lib/calculator.js:47:5)
    at Object.<anonymous> (/Users/scarfs03/.config/yarn/global/node_modules/libyear-yarn/lib/libyear-yarn.js:9:3)
    at Module._compile (internal/modules/cjs/loader.js:1063:30)
```

Digging in, the error is caused by yarn returning output that looks like this:

```@namespace/pkg                 1.5.1   exotic  exotic @namespace/pkg                   dependencies    https://github.com/namespace/pkg.git#1.5.1```

Which libyear-yarn isn't expecting and tries getting info from yarn about it, returning the above error. I dunno if it's the correct approach, but I lobbed together a dead simple test case and a fix which just skips any dependencies with a latest version of `exotic` and that seems to fix the issue for me.

Let me know if you need anything else!